### PR TITLE
econ, scouting and target assignment fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #  Infested Artosis (name pending)
 
-A small zerg bot initially clined from [JavaBWAPI](https://github.com/JavaBWAPI/jbwapi-java-template).
+A small zerg bot initially cloned from [JavaBWAPI](https://github.com/JavaBWAPI/jbwapi-java-template).
 
 ### Usage
 ```

--- a/src/main/java/unit/UnitRole.java
+++ b/src/main/java/unit/UnitRole.java
@@ -1,9 +1,10 @@
 package unit;
 
 public enum UnitRole {
-    GATHERER,
+    GATHER,
     SCOUT,
     FIGHT,
-    BUILDER,
+    BUILD,
     IDLE,
+    SCREEN, // Soak up damage on the front and detect non visible units
 }


### PR DESCRIPTION
- Production queue only pulls items of same importance per `onFrame`
- Scouting targets prioritizes starting locations first
- Scouts can only be assigned to starting locations until enemy main base is found
- Fixed bug where `FIGHT` units would not reassign closest unit